### PR TITLE
[pkar/bugfix/fix-vendored-jsontidier] 

### DIFF
--- a/cmd/json-ordered-tidy/main.go
+++ b/cmd/json-ordered-tidy/main.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 	"regexp"
 
-	"github.com/ActiveState/json-tools/pkg/jsontidier"
+	"github.com/ActiveState/json-ordered-tidy/pkg/jsontidier"
 )
 
 type config struct {


### PR DESCRIPTION
github.com/ActiveState/json-tools/pkg/jsontidier does not exist so non vendored packages fail when trying to install.